### PR TITLE
 Add a 'data' tab <-> 'analyses' tab toggle system

### DIFF
--- a/client/main/main.js
+++ b/client/main/main.js
@@ -90,6 +90,9 @@ $(document).ready(() => {
             if (event.key === 's')
                 ActionHub.get('save').do();
         }
+        else if (event.key === 'Escape') {
+            optionspanel.hideOptions();
+        }
     });
 
     if (host.isElectron && navigator.platform === 'Win32') {
@@ -125,6 +128,8 @@ $(document).ready(() => {
     ribbon.on('tabSelected', function(tabName) {
         if (tabName === 'file')
             backstage.activate();
+        else if (tabName === 'data')
+            optionspanel.hideOptions();
     });
 
     let halfWindowWidth = 585 + SplitPanelSection.sepWidth;
@@ -143,6 +148,8 @@ $(document).ready(() => {
                 analysis.ready.then(function() {
                     splitPanel.setVisibility('main-options', true);
                     optionspanel.setAnalysis(analysis);
+                    if (ribbonModel.get('selectedTab') === 'data')
+                        ribbonModel.set('selectedTab', 'analyses');
                 });
             }
             else {


### PR DESCRIPTION
- if the 'analyses' tab is active and the options panel is open and the
user clicks the 'data' tab the options panel closes.
- If the 'data' tab is active and through whatever mechanism the options
panel is opened and the 'analyses' tab becomes active.
- if the options panel is open pressing 'escape' closes the panel.
- closes #469