### PR TITLE
Add the ability to browse for .tsv files

### DIFF
--- a/client/main/backstage.js
+++ b/client/main/backstage.js
@@ -960,12 +960,12 @@ const BackstageModel = Backbone.Model.extend({
 
         let openExts = [
             { description: 'Data files', extensions: [
-                'omv', 'omt', 'csv', 'txt', 'ods', 'xlsx', 'sav', 'zsav', 'por',
+                'omv', 'omt', 'csv', 'tsv', 'txt', 'ods', 'xlsx', 'sav', 'zsav', 'por',
                 'rdata', 'rds', 'dta', 'sas7bdat', 'xpt', 'jasp',
             ]},
             { description: 'jamovi files (.omv)', extensions: ['omv'] },
             { description: 'jamovi templates (.omt)', extensions: ['omt'] },
-            { description: 'CSV (Comma delimited) (.csv, .txt)', extensions: ['csv', 'txt'] },
+            { description: 'CSV (Comma delimited) (.csv, .txt)', extensions: ['csv', 'tsv', 'txt'] },
             { description: 'Open Document (LibreOffice) (.ods)', extensions: ['ods'] },
             { description: 'Excel (.xlsx)', extensions: ['xlsx'] },
             { description: 'SPSS files (.sav, .zsav, .por)', extensions: ['sav', 'zsav', 'por'] },

--- a/server/jamovi/server/formatio/csv.py
+++ b/server/jamovi/server/formatio/csv.py
@@ -16,7 +16,7 @@ log = logging.getLogger('jamovi')
 
 
 def get_readers():
-    return [ ( 'csv', read ), ( 'txt', read ) ]
+    return [ ( 'csv', read ), ( 'tsv', read ), ( 'txt', read ) ]
 
 
 def get_writers():


### PR DESCRIPTION
The CSV parser correctly imports tab-separated value (TSV) formatted
data files, but the file picker does not include the commonly used .tsv
extension as an option. Rather than forcing users to rename their .tsv
files to .csv or .txt, include .tsv in the set of CSV-recognized file
extensions.

Signed-off-by: Dan Scott <dan@coffeecode.net>