### PR TITLE
VRANK transformation

### DIFF
--- a/client/main/vareditor/formulatoolbar.js
+++ b/client/main/vareditor/formulatoolbar.js
@@ -104,6 +104,8 @@ function allFunctions($functionsContent) {
     descriptions.VAR = { label: 'VAR( <i>number 1, number 2, \u2026</i>, ignore_missing=0 )', content: 'Returns the variance of a set of numbers.' };
     $functionsContent.append($('<div class="item" data-name="VVAR">VVAR</div>'));
     descriptions.VVAR = { label: 'VVAR( <i>variable</i>, group_by=0 )', content: 'Returns the variance of a variable.' };
+    $functionsContent.append($('<div class="item" data-name="VRANK">VRANK</div>'));
+    descriptions.VRANK = { label: 'VRANK( <i>variable</i>)', content: 'Returns the ranked values of a variable.' };
     $functionsContent.append($('<div class="item" data-name="Z">Z</div>'));
     descriptions.Z = { label: 'Z( <i>variable</i>, group_by=0 )', content: 'Returns the normalized values of a set of numbers.' };
 

--- a/server/jamovi/server/compute/functions.py
+++ b/server/jamovi/server/compute/functions.py
@@ -273,12 +273,16 @@ def BOXCOX(index, x: float, lmbda: float = VBOXCOXLAMBDA):
     else:
         return NaN
 
+@column_wise
+def VRANK(index: float):
+    values = filter(lambda x: not math.isnan(x), values)
+     # handled in nodes.Call.fvalue
+    return values
 
 @row_wise
 def Z(index, x: float):
     # see the transfudgifier
     return x
-
 
 @row_wise
 def ABSZ(index, x: float):

--- a/server/jamovi/server/compute/nodes.py
+++ b/server/jamovi/server/compute/nodes.py
@@ -404,7 +404,6 @@ class Call(ast.Call, Node):
             else:
                 break
 
-        print("f initiated")
         self.ranks = None
         ast.Call.__init__(self, func, args, keywords)
 


### PR DESCRIPTION
Hi,
This is an incomplete attempt to implement a rank transformation to a numerical variable. I have called it VRANK.
It is very different from other transformations because it cannot be applied row by row. All the values of the column are needed to get the ranks.
The current implementation may be not efficient but works and handles missing values. However it ignores filters, if you apply a filter, the ranks remain as with the complete dataset, and I think should be recalculated with the filtered observations.

I have tried but cannot follow the logic of the compute module and cannot find how to get if an observation is filtered or not. Probably you can fix that easily. Other enhancement would be to stratify ranks by a group_by variable=

The rank transformation would be very useful for nonparametric tests. If you can implement it in a better way, please reject this pull request.