### PR TITLE
Added support for in-dev languages

### DIFF
--- a/client/common/i18n.js
+++ b/client/common/i18n.js
@@ -115,8 +115,6 @@ class I18n {
 
     systemLanguage() {
 
-        return 'es';
-
         let languages = navigator.languages;
 
         if ( ! languages) {

--- a/client/common/i18n.js
+++ b/client/common/i18n.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Jed = require("jed");
+const Jed = require('jed');
 
 class I18n {
 
@@ -114,6 +114,9 @@ class I18n {
     }
 
     systemLanguage() {
+
+        return 'es';
+
         let languages = navigator.languages;
 
         if ( ! languages) {
@@ -185,7 +188,19 @@ class I18n {
         return parts;
     }
 
-    findBestMatchingLanguage(code, codes) {
+    findBestMatchingLanguage(code, codes, options) {
+
+        options = options || {};
+
+        if (options.excludeDev) {
+            let inDevSeparatorIndex = codes.indexOf('---');
+            if (inDevSeparatorIndex !== -1)
+                codes = codes.slice(0, inDevSeparatorIndex);
+        }
+        else {
+            codes = codes.filter(code => code !== '---');
+        }
+
         if (codes.includes(code))
             return code;
 

--- a/client/main/main.js
+++ b/client/main/main.js
@@ -45,8 +45,13 @@ try {
     let languages = await response.json();
     I18n.setAvailableLanguages(languages.available);
     let current = languages.current;
-    if ( ! current)
-        current = I18n.findBestMatchingLanguage(I18n.systemLanguage(), languages.available);
+    if ( ! current) {
+        let options = {};
+        if (host.isElectron)
+            // prevent the use of in-dev languages as 'system default' in electron
+            options.excludeDev = true;
+        current = I18n.findBestMatchingLanguage(I18n.systemLanguage(), languages.available, options);
+    }
     if ( ! current)
         current = 'en';
 

--- a/client/main/ribbon/appmenu.js
+++ b/client/main/ribbon/appmenu.js
@@ -197,11 +197,17 @@ const AppMenuButton = Backbone.View.extend({
         this.model.settings().on('change:selectedLanguage', () => this._updateUI());
 
         let available = i18n.availableLanguages().map((code) => {
+            if (code === '---')
+                return `</optgroup><optgroup label="${ _('In development') }">`;
             let ownName = new Intl.DisplayNames([code], { type: 'language' }).of(code);
             ownName = `${ ownName[0].toUpperCase() }${ ownName.slice(1) }`; // capitalise first letter
             return `<option value="${ code }">${ ownName }</option>`;
         });
-        available.unshift(`<option value="">${ 'System default' }</option>`);
+        available.unshift(`<optgroup label="${ _('Available') }">`)
+        available.push('</optgroup>')
+
+        available.unshift(`<option value="">${ _('System default') }</option>`);
+
 
         this.$languageList[0].innerHTML = available.join('');
 


### PR DESCRIPTION
The change is simply to add a `---` to separate the 'production' languages from the 'in-dev' ones in the manifest.

the manifest ends up looking like:

```
{
    "current": "",
    "available": [
        "en",
        "de",
        "es",
        "it",
        "ja",
        "no",
        "pt",
        "zh-cn",
        "---",
        "hr",
        "pl",
        "ru",
        "sl"
    ]
}
```

and the menu ends up looking like:

<img width="180" alt="Screen Shot 2022-03-23 at 13 42 50" src="https://user-images.githubusercontent.com/3240247/159613501-f5a00d1e-5698-4183-9044-ffa808b3e0dd.png">
