### PR TITLE
Improvements to welcome

### DIFF
--- a/client/main/results.css
+++ b/client/main/results.css
@@ -15,18 +15,23 @@
     background-color: white ;
 }
 
-.silky-welcome-panel {
+.jmv-welcome-panel {
+    width: 100% ;
+    height: 100% ;
+    background-color: white ;
+    position: relative ; /* this is necessary, but not sure why */
+}
+
+.jmv-welcome-iframe {
+    box-sizing: border-box;
     border: none;
     width: 100% ;
     height: 100% ;
-    box-sizing: border-box;
-    position: relative ;
-    top: 0 ;
     overflow: scroll ;
     background-color: white ;
 }
 
-.jmv-results-panel.jmv-results-panel-hidden, .silky-welcome-panel.silky-welcome-panel-hidden {
+.jmv-results-panel.jmv-results-panel-hidden, .jmv-welcome-panel.jmv-welcome-panel-hidden {
     width: 0 ;
     overflow: hidden ;
     padding-right: 0 ;


### PR DESCRIPTION
an issue has arisen when our jamovi.org server is down, and a 500 error page is displayed where the results panel should go. it's quite an imposing message, and people assume that jamovi isn't working (when it doesn't actually affect anything).

this PR only displays the iframe if it receives a 'ready' message from the iframe's content ... any sort of error page will not send a ready message, and jamovi will not display them.