### PR TITLE
engine: fix handle leak in Host::isOrphan() on Windows

### DIFF
--- a/engine/engine/host.cpp
+++ b/engine/engine/host.cpp
@@ -16,6 +16,7 @@ bool Host::isOrphan()
 #ifdef _WIN32
 
     static DWORD ppid = 0;
+    static HANDLE parent = NULL;
 
     if (ppid == 0) {
         HANDLE h = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
@@ -35,10 +36,12 @@ bool Host::isOrphan()
          CloseHandle(h);
     }
 
-    if (ppid != 0) {
-        HANDLE h = OpenProcess(PROCESS_QUERY_INFORMATION, false, ppid);
+    if (parent == NULL && ppid != 0)
+        parent = OpenProcess(PROCESS_QUERY_INFORMATION, false, ppid);
+
+    if (parent != NULL) {
         DWORD exitCode = 0;
-        if (GetExitCodeProcess(h, &exitCode))
+        if (GetExitCodeProcess(parent, &exitCode))
                 return exitCode != STILL_ACTIVE;
     }
     return false;


### PR DESCRIPTION
## Summary

On Windows, `Host::isOrphan()` (`engine/engine/host.cpp`) opens a handle to the
parent process with `OpenProcess()` on every call but never closes it:

```cpp
if (ppid != 0) {
    HANDLE h = OpenProcess(PROCESS_QUERY_INFORMATION, false, ppid);
    DWORD exitCode = 0;
    if (GetExitCodeProcess(h, &exitCode))
            return exitCode != STILL_ACTIVE;
}
```

`isOrphan()` is called from `Engine::periodicChecks()` roughly every 250 ms
while the engine is idle (`engine.cpp`), so the engine leaks a process handle
several times per second.

## Impact

On a Windows machine left running for a few days I found each `jamovi-engine`
process holding **~990,000 open handles** (≈4 million across the four engine
processes). Besides the wasted resources, an unbounded handle count can
eventually reach the per-process handle limit and destabilise the engine.

## Fix

Open the parent handle **once** and cache it, exactly as the server already
does in `Utils::isParentAlive()` (`server/jamovi/common/utils.cpp`). There is
no behavioural change other than no longer leaking the handle; the engine and
the server now perform the parent-liveness check the same way.

The non-Windows code path is unchanged.
